### PR TITLE
Trigger POI observed if both agent and POI are within sensor range

### DIFF
--- a/include/rovers/core/poi/count_constraint.hpp
+++ b/include/rovers/core/poi/count_constraint.hpp
@@ -3,6 +3,7 @@
 
 #include <rovers/core/poi/poi.hpp>
 #include <rovers/core/rover/rover.hpp>
+#include <rovers/utilities/math/norms.hpp>
 
 namespace rovers {
 
@@ -18,7 +19,8 @@ class CountConstraint {
     [[nodiscard]] bool is_satisfied(const EntityPack& entity_pack) const {
         size_t count = 0;
         for (const auto& rover : entity_pack.agents) {
-            if (rover->obs_radius() <= entity_pack.entity->obs_radius()) {
+            double dist = l2_norm(rover->position(), entity_pack.entity->position());
+            if (dist <= rover->obs_radius() && dist <= entity_pack.entity->obs_radius()) {
                 ++count;
                 if (count >= count_constraint) return true;
             }

--- a/include/rovers/core/poi/type_constraint.hpp
+++ b/include/rovers/core/poi/type_constraint.hpp
@@ -3,6 +3,7 @@
 
 #include <rovers/core/poi/poi.hpp>
 #include <rovers/core/rover/rover.hpp>
+#include <rovers/utilities/math/norms.hpp>
 
 namespace rovers {
 
@@ -18,7 +19,8 @@ class TypeConstraint {
     [[nodiscard]] bool is_satisfied(const EntityPack& entity_pack) const {
         size_t count = 0;
         for (const auto& rover : entity_pack.agents) {
-            if (rover->obs_radius() <= entity_pack.entity->obs_radius()) {
+            double dist = l2_norm(rover->position(), entity_pack.entity->position());
+            if (dist <= rover->obs_radius() && dist <= entity_pack.entity->obs_radius()) {
                 ++count;
                 if (count >= count_constraint) return true;
             }

--- a/python/render_rovers.py
+++ b/python/render_rovers.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
         rovers.Drone()
     ]
     pois = [
-        rovers.POI[rovers.CountConstraint](3),
+        rovers.POI[rovers.CountConstraint](3, 1.0, 1),
         rovers.POI[rovers.TypeConstraint](2, 1.0),
         rovers.POI[rovers.TypeConstraint](5),
         rovers.POI[rovers.TypeConstraint](2)


### PR DESCRIPTION
Originally the POI observed state would trigger if a rover's observation radius is less than the POI's observation radius, regardless of their distance from each other. Now it triggers if both the POI can see the rover and the rover can see the POI. I can adjust it if that's not the behavior we're looking for.